### PR TITLE
Add support for building SP Link nifs on linux x64

### DIFF
--- a/server/lib/mix/tasks/sp_nifs.compile.ex
+++ b/server/lib/mix/tasks/sp_nifs.compile.ex
@@ -8,7 +8,7 @@ defmodule Mix.Tasks.SpNifs.Compile do
 
     case :os.type() do
       {:unix, :darwin} -> compile(:macos, arch())
-      {:unix, :linux} -> compile(:linux, :x64)
+      {:unix, :linux} -> compile(:linux, arch())
       {:unix, :freebsd} -> compile(:linux, arch())
       {:unix, :openbsd} -> compile(:linux, arch())
       {:win32, :nt} -> compile(:win, arch())


### PR DESCRIPTION
### Issue

Latest commit a3f5f5e93925616af651dbd04e5f9de4ed8ce7ce broke dev runs on Linux because `sp_nifs.compile` could not recognize os `:linux, :x64`

![2025-01-27-225910_1102x550_scrot](https://github.com/user-attachments/assets/6194fc59-4b92-474a-92a3-4867031eb442)


### Solution

Updated `server/lib/mix/tasks/sp_nifs.compile.ex` by adding a new function which invokes `cmake` commands to locally build the library at `deps/sp_link/build` and installs it during `mix setup`

![2025-01-27-230208_1549x400_scrot](https://github.com/user-attachments/assets/77db36f8-cae4-4843-b94b-6079454c311a)

Tested as working on Arch Linux running on a Dell Latitude 14 5420 (11th Gen Intel Core i7, 16GB DDR4, 512GB PCIe NVMe SSD)