### PR TITLE
Get the dev GUI building on Windows

### DIFF
--- a/gui/main.cpp
+++ b/gui/main.cpp
@@ -1,9 +1,13 @@
 #include <iostream>
 #include <memory>
 #include <cstdlib>
+#include <QtGlobal>
 #ifndef Q_OS_WIN
 #include <unistd.h>
 #else
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
 #include <windows.h>
 #include <io.h>
 #include <fcntl.h>


### PR DESCRIPTION
There appeared to be two issues that needed fixing:
- `Q_OS_WIN` was not defined before it was referenced
- Header file conflicts that included multiple Winsock versions

Though defining WIN32_LEAN_AND_MEAN appeared to solve the immediate build issue, I'm not 100% sure whether it has any undesirable flow-on effects - so please feel free to close or modify this PR if desired.
(Fixes https://github.com/samaaron/tau5/issues/5)